### PR TITLE
Make the element display: inline-block.

### DIFF
--- a/file-upload.html
+++ b/file-upload.html
@@ -22,6 +22,10 @@ Example:
 <dom-module id="file-upload">
 
   <style type="text/css">
+    :host {
+        display: inline-block;
+    }
+    
     .enabled {
       border: 1px dashed #555;
       @apply(--file-upload-upload-border-enabled);


### PR DESCRIPTION
We want margin and padding to work without having to explicitly set display: inline-block or display: block.
