### PR TITLE
Support S3 POST uploads and 2xx response codes

### DIFF
--- a/file-upload.html
+++ b/file-upload.html
@@ -491,7 +491,7 @@ Example:
         }
       }
       xhr.onload = function(e) {
-        if (xhr.status === 200) {
+        if (xhr.status >= 200 && xhr.status <= 206) {
           self.fire("success", {xhr: xhr});
           self.set(prefix + ".complete", true);
         } else {

--- a/file-upload.html
+++ b/file-upload.html
@@ -462,7 +462,6 @@ Example:
       var self = this;
 
       var formData = new FormData();
-      formData.append("file", file, file.name);
 
        /*
         Add additional data to send with the POST variable
@@ -473,6 +472,9 @@ Example:
             formData.append(key, addData[key]);
           }
       }
+
+      // Add the file data last to support POSTing to Amazon Web Services S3.
+      formData.append("file", file, file.name);
 
       var xhr = file.xhr = new XMLHttpRequest();
 


### PR DESCRIPTION
Pretty minor change I made to support uploading files directly to S3 using pre-signed POST requests. 
The documentation makes only one reference to the field order and states that "[The file or content must be the last field in the form.](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTForms.html)".

I've also extended the range of HTTP responses that trigger the success callback as it was only "200 OK" but I'm using "201 Created".
