### PR TITLE
Seperate icons

### DIFF
--- a/file-upload-icons.html
+++ b/file-upload-icons.html
@@ -1,0 +1,13 @@
+<link rel="import" href="../iron-icon/iron-icon.html">
+<link rel="import" href="../iron-iconset-svg/iron-iconset-svg.html">
+
+<iron-iconset-svg name="file-upload-icons" size="24">
+    <svg>
+        <defs>
+            <g id="file-upload"><path d="M9 16h6v-6h4l-7-7-7 7h4zm-4 2h14v2H5z"/></g>
+            <g id="autorenew"><path d="M12 6v3l4-4-4-4v3c-4.42 0-8 3.58-8 8 0 1.57.46 3.03 1.24 4.26L6.7 14.8c-.45-.83-.7-1.79-.7-2.8 0-3.31 2.69-6 6-6zm6.76 1.74L17.3 9.2c.44.84.7 1.79.7 2.8 0 3.31-2.69 6-6 6v-3l-4 4 4 4v-3c4.42 0 8-3.58 8-8 0-1.57-.46-3.03-1.24-4.26z"/></g>
+            <g id="cancel"><path d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"/></g>
+            <g id="check-circle"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/></g>
+        </defs>
+    </svg>
+</iron-iconset-svg>

--- a/file-upload.html
+++ b/file-upload.html
@@ -17,7 +17,7 @@ Example:
 
 <link rel="import" href="../paper-button/paper-button.html">
 <link rel="import" href="../paper-progress/paper-progress.html">
-  <link rel="import" href="../iron-icons/iron-icons.html">
+<link rel="import" href="file-upload-icons.html">
 
 <dom-module id="file-upload">
 
@@ -100,7 +100,7 @@ Example:
 
   <template>
     <div>
-      <paper-button id="button" icon="file-upload" class="blue" on-click="_fileClick">
+      <paper-button id="button" icon="file-upload-icons:file-upload" class="blue" on-click="_fileClick">
         <content></content>
       </paper-button>
       <div id='UploadBorder'>
@@ -110,9 +110,9 @@ Example:
             <div class="name">
               <span>{{item.name}}</span>
               <div class="commands">
-                <iron-icon icon="autorenew" title="{{retryText}}" on-click="_retryUpload" hidden$="{{!item.error}}"></iron-icon>
-                <iron-icon icon="cancel" title="{{removeText}}" on-click="_cancelUpload" hidden$="{{item.complete}}"></iron-icon>
-                <iron-icon icon="check-circle" title="{{successText}}" hidden$="{{!item.complete}}"></iron-icon>
+                <iron-icon icon="file-upload-icons:autorenew" title="{{retryText}}" on-click="_retryUpload" hidden$="{{!item.error}}"></iron-icon>
+                <iron-icon icon="file-upload-icons:cancel" title="{{removeText}}" on-click="_cancelUpload" hidden$="{{item.complete}}"></iron-icon>
+                <iron-icon icon="file-upload-icons:check-circle" title="{{successText}}" hidden$="{{!item.complete}}"></iron-icon>
               </div>
             </div>
             <div class="error" hidden$="{{!item.error}}">{{errorText}}</div>


### PR DESCRIPTION
Seperate icons into custom iconset so the full icon library won't be appended in production systems.

When you use a build script and append imports into a bundled version it's recommended to have a custom iconset with only the icons used by the component.
