### PR TITLE
Fix drag and drop from download bar for Chrome/OSX

### DIFF
--- a/file-upload.html
+++ b/file-upload.html
@@ -337,6 +337,16 @@ Example:
       this.ondragover = function(e) {
         e.stopPropagation();
         this.toggleClass("hover", true, uploadBorder);
+
+        // Workaround for allowgin drop from Chome's download footer on OSX
+        // See https://bugs.chromium.org/p/chromium/issues/detail?id=234931
+        var effect = e.dataTransfer && e.dataTransfer.dropEffect;
+        var effectAllowed = e.dataTransfer && e.dataTransfer.effectAllowed;
+        if (effect === 'none' && effectAllowed != 'none') {
+          e.dataTransfer.dropEffect = effectAllowed == 'move' ? 'move' : 'copy'
+        }
+        // end of workaround
+
         return false;
       }
 


### PR DESCRIPTION
The drop event is not fired when dragging a file from the download bar on Google Chrome (tested on OSX). After searching for a while it appears that it is a bug in Chrome itself.

https://bugs.chromium.org/p/chromium/issues/detail?id=234931

The workaround provided in the bug thread fixes Drag&Drop feature when the file
is dragged from the download bar. feel free to merge it if you consider it relevant
