### PR TITLE
limit list to 1 file if multi=false

### DIFF
--- a/file-upload.html
+++ b/file-upload.html
@@ -441,12 +441,18 @@ Example:
      */
     _fileChange: function(e) {
       var length = e.target.files.length;
+    
       for (var i = 0; i < length; i++) {
         var file = e.target.files[i];
         file.progress = 0;
         file.error = false;
         file.complete = false;
-        this.push('files', file);
+        if (!this.multi){
+          this.set('files',[file]);
+        }
+        else{
+          this.push('files', file);
+        }
         if (!this.manualUpload) {
           this.uploadFile(file);
         }

--- a/file-upload.html
+++ b/file-upload.html
@@ -107,7 +107,7 @@ Example:
       <paper-button id="button" icon="file-upload-icons:file-upload" class="blue" on-click="_fileClick" alt="{{paperButtonAlt}}" title="{{paperButtonTitle}}">
         <content></content>
       </paper-button>
-      <div id='UploadBorder'>
+      <div id='UploadBorder' hidden$="{{!showFileList}}">
         <div id="dropArea" hidden$="{{!_shownDropText}}">{{dropText}}</div>
         <template is="dom-repeat" items="{{files}}">
           <div class="file">
@@ -176,6 +176,16 @@ Example:
         type: String,
         value: ''
       },
+
+
+      /**
+       * `showFileList` indicates whether or not the file list should be hidden.
+       */
+      showFileList: {
+        type: Boolean,
+        value: true
+      },
+
 
       /**
        * `progressHidden` indicates whether or not the progress bar should be hidden.
@@ -441,7 +451,7 @@ Example:
      */
     _fileChange: function(e) {
       var length = e.target.files.length;
-    
+
       for (var i = 0; i < length; i++) {
         var file = e.target.files[i];
         file.progress = 0;

--- a/file-upload.html
+++ b/file-upload.html
@@ -107,7 +107,7 @@ Example:
       <paper-button id="button" icon="file-upload-icons:file-upload" class="blue" on-click="_fileClick" alt="{{paperButtonAlt}}" title="{{paperButtonTitle}}">
         <content></content>
       </paper-button>
-      <div id='UploadBorder' hidden$="{{!showFileList}}">
+      <div id='UploadBorder' hidden$="{{hideFileList}}">
         <div id="dropArea" hidden$="{{!_shownDropText}}">{{dropText}}</div>
         <template is="dom-repeat" items="{{files}}">
           <div class="file">
@@ -181,11 +181,10 @@ Example:
       /**
        * `showFileList` indicates whether or not the file list should be hidden.
        */
-      showFileList: {
+      hideFileList: {
         type: Boolean,
-        value: true
+        value: false
       },
-
 
       /**
        * `progressHidden` indicates whether or not the progress bar should be hidden.


### PR DESCRIPTION
When multi=false and I select one file, and after select another file, there is 2 files instead of one.
It fixes that.
